### PR TITLE
Update Gradle plugin to 1.2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:1.2.0-beta1'
+    classpath 'com.android.tools.build:gradle:1.2.3'
     classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
   }
 }


### PR DESCRIPTION
The previous plugin is not working on Android Studio 1.2.

Error details: "Plugin is too old, please update to a more recent version, or set ANDROID_DAILY_OVERRIDE environment variable to..."