### PR TITLE
Use @inject-annotated constructor for navigator

### DIFF
--- a/presentation/src/main/java/com/fernandocejas/android10/sample/presentation/internal/di/modules/ApplicationModule.java
+++ b/presentation/src/main/java/com/fernandocejas/android10/sample/presentation/internal/di/modules/ApplicationModule.java
@@ -45,10 +45,6 @@ public class ApplicationModule {
     return this.application;
   }
 
-  @Provides @Singleton Navigator provideNavigator() {
-    return new Navigator();
-  }
-
   @Provides @Singleton ThreadExecutor provideThreadExecutor(JobExecutor jobExecutor) {
     return jobExecutor;
   }

--- a/presentation/src/main/java/com/fernandocejas/android10/sample/presentation/navigation/Navigator.java
+++ b/presentation/src/main/java/com/fernandocejas/android10/sample/presentation/navigation/Navigator.java
@@ -29,7 +29,7 @@ import javax.inject.Singleton;
 public class Navigator {
 
   @Inject
-  public void Navigator() {
+  public Navigator() {
     //empty
   }
 


### PR DESCRIPTION
Since Navigator can be constructed by the @inject-annotated constructor, there is no need to provide it in  a module. @provide-annotations should only be used for interfaces, third-party classes or objects which have to be configured. None of these apply here.