### PR TITLE
nulling the reference to the activity in onDetach to avoid leaks

### DIFF
--- a/presentation/src/main/java/com/fernandocejas/android10/sample/presentation/view/fragment/UserListFragment.java
+++ b/presentation/src/main/java/com/fernandocejas/android10/sample/presentation/view/fragment/UserListFragment.java
@@ -60,6 +60,11 @@ public class UserListFragment extends BaseFragment implements UserListView {
     }
   }
 
+  @Override public void onDetach() {
+    super.onDetach();
+    this.userListListener = null;
+  }
+
   @Override public View onCreateView(LayoutInflater inflater, ViewGroup container,
       Bundle savedInstanceState) {
 


### PR DESCRIPTION
If a Fragment is detached all references to the detaching activity should be removed, this PR sets the userListListener of the UserListFragment to null in onDetach()