### PR TITLE
Fixing broken tests that were referring to non-existing fragment ids.

### DIFF
--- a/presentation/src/androidTest/java/com/fernandocejas/android10/sample/test/view/activity/UserDetailsActivityTest.java
+++ b/presentation/src/androidTest/java/com/fernandocejas/android10/sample/test/view/activity/UserDetailsActivityTest.java
@@ -53,7 +53,7 @@ public class UserDetailsActivityTest extends ActivityInstrumentationTestCase2<Us
 
   public void testContainsUserDetailsFragment() {
     Fragment userDetailsFragment =
-        userDetailsActivity.getFragmentManager().findFragmentById(R.id.fl_fragment);
+        userDetailsActivity.getFragmentManager().findFragmentById(R.id.fragmentContainer);
     assertThat(userDetailsFragment, is(notNullValue()));
   }
 

--- a/presentation/src/androidTest/java/com/fernandocejas/android10/sample/test/view/activity/UserListActivityTest.java
+++ b/presentation/src/androidTest/java/com/fernandocejas/android10/sample/test/view/activity/UserListActivityTest.java
@@ -45,7 +45,7 @@ public class UserListActivityTest extends ActivityInstrumentationTestCase2<UserL
 
   public void testContainsUserListFragment() {
     Fragment userListFragment =
-        userListActivity.getFragmentManager().findFragmentById(R.id.fragmentUserList);
+        userListActivity.getFragmentManager().findFragmentById(R.id.fragmentContainer);
     assertThat(userListFragment, is(notNullValue()));
   }
 


### PR DESCRIPTION
The tests won't compile.  So we went into the code to find what the Fragment Manager was actually using.  And fixed it.

- @margaretmz @robert-wallis