### PR TITLE
Make domain and data modules dependent on javax.inject instead of dagger 2

### DIFF
--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -18,6 +18,7 @@ ext {
   rxJavaVersion = '1.0.14'
   rxAndroidVersion = '1.0.1'
   javaxAnnotationVersion = '1.0'
+  javaxInjectVersion = '1'
   gsonVersion = '2.3'
   okHttpVersion = '2.5.0'
   androidAnnotationsVersion = '21.0.3'
@@ -56,6 +57,7 @@ ext {
       daggerCompiler:     "com.google.dagger:dagger-compiler:${daggerVersion}",
       dagger:             "com.google.dagger:dagger:${daggerVersion}",
       javaxAnnotation:    "javax.annotation:jsr250-api:${javaxAnnotationVersion}",
+      javaxInject:        "javax.inject:javax.inject:${javaxInjectVersion}",
       rxJava:             "io.reactivex:rxjava:${rxJavaVersion}",
   ]
 
@@ -72,6 +74,7 @@ ext {
       rxJava:             "io.reactivex:rxjava:${rxJavaVersion}",
       rxAndroid:          "io.reactivex:rxandroid:${rxAndroidVersion}",
       javaxAnnotation:    "javax.annotation:jsr250-api:${javaxAnnotationVersion}",
+      javaxInject:        "javax.inject:javax.inject:${javaxInjectVersion}",
       androidAnnotations: "com.android.support:support-annotations:${androidAnnotationsVersion}"
   ]
 

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -53,9 +53,8 @@ dependencies {
   def testDependencies = rootProject.ext.dataTestDependencies
 
   compile project(':domain')
-  apt dataDependencies.daggerCompiler
   provided dataDependencies.javaxAnnotation
-  compile dataDependencies.dagger
+  compile dataDependencies.javaxInject
   compile dataDependencies.okHttp
   compile dataDependencies.gson
   compile dataDependencies.rxJava

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -19,10 +19,9 @@ dependencies {
   def domainDependencies = rootProject.ext.domainDependencies
   def domainTestDependencies = rootProject.ext.domainTestDependencies
 
-  provided domainDependencies.daggerCompiler
   provided domainDependencies.javaxAnnotation
 
-  compile domainDependencies.dagger
+  compile domainDependencies.javaxInject
   compile domainDependencies.rxJava
 
   testCompile domainTestDependencies.junit


### PR DESCRIPTION
Dagger 2 has implicit dependency:
```
+--- com.google.dagger:dagger:2.0.2
|    \--- javax.inject:javax.inject:1
```

Domain and Data modules don't depend on any class from the Dagger 2 API.
They need only `@Inject` annotation, so it makes no sense to have the entire library in classpath.