### PR TITLE
Fixing the assigned value to the exception message

### DIFF
--- a/data/src/main/java/com/fernandocejas/android10/sample/data/exception/RepositoryErrorBundle.java
+++ b/data/src/main/java/com/fernandocejas/android10/sample/data/exception/RepositoryErrorBundle.java
@@ -37,7 +37,7 @@ public class RepositoryErrorBundle implements ErrorBundle {
   public String getErrorMessage() {
     String message = "";
     if (this.exception != null) {
-      this.exception.getMessage();
+      message = this.exception.getMessage();
     }
     return message;
   }


### PR DESCRIPTION
The message of the exception will always return with empty text as assigning value was missing in the if condition of getErrorMessage method