### PR TITLE
Update .gitignore to ignore .gradletasknamecache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Thumbs.db
 *.class
   
 # generated files
+.gradletasknamecache
 bin/
 gen/
 build/


### PR DESCRIPTION
I figure I'd submit this PR and let the world decide what should happen with it.  It is context specific so bear with me.

### Context
When building from the command line using the [gradle plugin](https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/gradle/gradle.plugin.zsh) for [oh-my-zsh](http://ohmyz.sh/), the `.gradletasknamecache` file is generated to aid with autocompletion.

### Solution
This PR adds the gradle tasknamecache file to `.gitignore` as a generated file.