### PR TITLE
update gradles to make the build pass on Android Studio 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ android:
     - tools
     - platform-tools
     - tools
-    - build-tools-24.0.1
-    - android-23
+    - build-tools-27.0.1
+    - android-26
     - extra-google-m2repository
     - extra-android-m2repository
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,11 @@ buildscript {
   repositories {
     jcenter()
     mavenCentral()
+    google()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.2'
-    classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
+    classpath 'com.android.tools.build:gradle:3.0.0'
+//    classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     google()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.0.0'
+    classpath 'com.android.tools.build:gradle:3.0.1'
 //    classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
   }
 }

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -6,22 +6,22 @@ allprojects {
 
 ext {
   //Android
-  androidBuildToolsVersion = "24.0.1"
+  androidBuildToolsVersion = "27.0.1"
   androidMinSdkVersion = 15
-  androidTargetSdkVersion = 21
-  androidCompileSdkVersion = 21
+  androidTargetSdkVersion = 26
+  androidCompileSdkVersion = 26
 
   //Libraries
   daggerVersion = '2.8'
   butterKnifeVersion = '7.0.1'
-  recyclerViewVersion = '21.0.3'
+  recyclerViewVersion = '25.4.0'
   rxJavaVersion = '2.0.2'
   rxAndroidVersion = '2.0.1'
   javaxAnnotationVersion = '1.0'
   javaxInjectVersion = '1'
   gsonVersion = '2.3'
   okHttpVersion = '2.5.0'
-  androidAnnotationsVersion = '21.0.3'
+  androidAnnotationsVersion = '25.4.0'
   arrowVersion = '1.0.0'
 
   //Testing
@@ -30,7 +30,7 @@ ext {
   assertJVersion = '1.7.1'
   mockitoVersion = '1.9.5'
   dexmakerVersion = '1.0'
-  espressoVersion = '2.0'
+  espressoVersion = '3.0.1'
   testingSupportLibVersion = '0.1'
 
   //Development

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'me.tatarka:gradle-retrolambda:3.2.3'
+    classpath 'me.tatarka:gradle-retrolambda:3.7.0'
   }
 }
 
@@ -51,19 +51,19 @@ dependencies {
   def dataDependencies = rootProject.ext.dataDependencies
   def testDependencies = rootProject.ext.dataTestDependencies
 
-  compile project(':domain')
-  provided dataDependencies.javaxAnnotation
-  compile dataDependencies.javaxInject
-  compile dataDependencies.okHttp
-  compile dataDependencies.gson
-  compile dataDependencies.rxJava
-  compile dataDependencies.rxAndroid
-  compile dataDependencies.androidAnnotations
+  implementation project(':domain')
+  compileOnly dataDependencies.javaxAnnotation
+  implementation dataDependencies.javaxInject
+  implementation dataDependencies.okHttp
+  implementation dataDependencies.gson
+  implementation dataDependencies.rxJava
+  implementation dataDependencies.rxAndroid
+  implementation dataDependencies.androidAnnotations
 
-  testCompile testDependencies.junit
-  testCompile testDependencies.assertj
-  testCompile testDependencies.mockito
-  testCompile testDependencies.robolectric
+  testImplementation testDependencies.junit
+  testImplementation testDependencies.assertj
+  testImplementation testDependencies.mockito
+  testImplementation testDependencies.robolectric
 }
 
 repositories {

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'com.neenbedankt.android-apt'
+//apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'me.tatarka.retrolambda'
 
 android {
@@ -64,4 +64,8 @@ dependencies {
   testCompile testDependencies.assertj
   testCompile testDependencies.mockito
   testCompile testDependencies.robolectric
+}
+
+repositories {
+  google()
 }

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -19,13 +19,13 @@ dependencies {
   def domainDependencies = rootProject.ext.domainDependencies
   def domainTestDependencies = rootProject.ext.domainTestDependencies
 
-  provided domainDependencies.javaxAnnotation
+  compileOnly domainDependencies.javaxAnnotation
 
-  compile domainDependencies.javaxInject
-  compile domainDependencies.rxJava
+  implementation domainDependencies.javaxInject
+  implementation domainDependencies.rxJava
   compile domainDependencies.arrow
 
-  testCompile domainTestDependencies.junit
-  testCompile domainTestDependencies.mockito
-  testCompile domainTestDependencies.assertj
+  testImplementation domainTestDependencies.junit
+  testImplementation domainTestDependencies.mockito
+  testImplementation domainTestDependencies.assertj
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.android.application'
-apply plugin: 'com.neenbedankt.android-apt'
+//apply plugin: 'com.neenbedankt.android-apt'
 
 android {
   def globalConfiguration = rootProject.extensions.getByName("ext")
@@ -65,9 +65,10 @@ dependencies {
   compile project(':domain')
   compile project(':data')
 
-  apt presentationDependencies.daggerCompiler
+  annotationProcessor presentationDependencies.daggerCompiler
   compile presentationDependencies.dagger
   compile presentationDependencies.butterKnife
+  annotationProcessor presentationDependencies.butterKnife
   compile presentationDependencies.recyclerView
   compile presentationDependencies.rxJava
   compile presentationDependencies.rxAndroid
@@ -81,4 +82,8 @@ dependencies {
 
   //Development
   compile developmentDependencies.leakCanary
+}
+
+repositories {
+  google()
 }

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -62,26 +62,26 @@ dependencies {
   def presentationTestDependencies = rootProject.ext.presentationTestDependencies
   def developmentDependencies = rootProject.ext.developmentDependencies
 
-  compile project(':domain')
-  compile project(':data')
+  implementation project(':domain')
+  implementation project(':data')
 
   annotationProcessor presentationDependencies.daggerCompiler
-  compile presentationDependencies.dagger
-  compile presentationDependencies.butterKnife
+  implementation presentationDependencies.dagger
+  implementation presentationDependencies.butterKnife
   annotationProcessor presentationDependencies.butterKnife
-  compile presentationDependencies.recyclerView
-  compile presentationDependencies.rxJava
-  compile presentationDependencies.rxAndroid
-  provided presentationDependencies.javaxAnnotation
+  implementation presentationDependencies.recyclerView
+  implementation presentationDependencies.rxJava
+  implementation presentationDependencies.rxAndroid
+  compileOnly presentationDependencies.javaxAnnotation
 
-  androidTestCompile presentationTestDependencies.mockito
-  androidTestCompile presentationTestDependencies.dexmaker
-  androidTestCompile presentationTestDependencies.dexmakerMockito
-  androidTestCompile presentationTestDependencies.espresso
-  androidTestCompile presentationTestDependencies.testingSupportLib
+  androidTestImplementation presentationTestDependencies.mockito
+  androidTestImplementation presentationTestDependencies.dexmaker
+  androidTestImplementation presentationTestDependencies.dexmakerMockito
+  androidTestImplementation presentationTestDependencies.espresso
+  androidTestImplementation presentationTestDependencies.testingSupportLib
 
   //Development
-  compile developmentDependencies.leakCanary
+  implementation developmentDependencies.leakCanary
 }
 
 repositories {


### PR DESCRIPTION
I updated some build.gradle files to make the project synced and built successfully.
Android Studio 3.0 changed the default gradle tool version. and the gradle update introduces some new syntax for build.gradle.