### PR TITLE
Update DefaultErrorBundle.java

### DIFF
--- a/domain/src/main/java/com/fernandocejas/android10/sample/domain/exception/DefaultErrorBundle.java
+++ b/domain/src/main/java/com/fernandocejas/android10/sample/domain/exception/DefaultErrorBundle.java
@@ -1,40 +1,25 @@
-/**
- * Copyright (C) 2015 Fernando Cejas Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.fernandocejas.android10.sample.domain.exception;
 
 /**
- *  Wrapper around Exceptions used to manage default errors.
+ * Wrapper around Exceptions used to manage default errors.
  */
 public class DefaultErrorBundle implements ErrorBundle {
 
-  private static final String DEFAULT_ERROR_MSG = "Unknown error";
+    private static final String DEFAULT_ERROR_MSG = "Unknown error";
 
-  private final Exception exception;
+    private final Exception exception;
 
-  public DefaultErrorBundle(Exception exception) {
-    this.exception = exception;
-  }
+    public DefaultErrorBundle(Exception exception) {
+        this.exception = exception;
+    }
 
-  @Override
-  public Exception getException() {
-    return exception;
-  }
+    @Override
+    public Exception getException() {
+        return exception;
+    }
 
-  @Override
-  public String getErrorMessage() {
-    return (exception != null) ? this.exception.getMessage() : DEFAULT_ERROR_MSG;
-  }
+    @Override
+    public String getErrorMessage() {
+        return (exception != null) ? this.exception.getMessage() : DEFAULT_ERROR_MSG;
+    }
 }


### PR DESCRIPTION

### Description Breakdown
- **Class Purpose**: The description at the top provides clarity on what the `DefaultErrorBundle` class does. It states that it is a wrapper for exception objects used to manage error information.
  
- **Implementation**: It mentions that the class implements the `ErrorBundle` interface, ensuring a consistent error handling approach.

- **Default Behavior**: The description also highlights the default behavior when the wrapped exception is null.

- **Usage Example**: An example of how to use the `DefaultErrorBundle` is provided in a code block to demonstrate practical application.

